### PR TITLE
feat: いいね機能を追加

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -181,6 +181,7 @@ export default function Index() {
           completed_dates: updatedCompletedDates,
           streak,
           total_days: updatedCompletedDates.length,
+          achieved_at: !isCompleted ? new Date().toISOString() : null,
         })
         .eq('id', habitId)
         .eq('user_id', session?.user?.id)

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -49,16 +49,17 @@ export default function Index() {
     return maxStreak;
   }
 
-  const [habits, setHabits] = useState<
-    {
-      id: string;
-      name: string;
-      streak: number;
-      completedDates: string[];
-      totalDays: number;
-      is_public: boolean;
-    }[]
-  >([]);
+  type Habit = {
+    id: string;
+    name: string;
+    streak: number;
+    completedDates: string[];
+    totalDays: number;
+    is_public: boolean;
+    achieved_at?: string;
+  };
+
+  const [habits, setHabits] = useState<Habit[]>([]);
   const [newHabit, setNewHabit] = useState('');
   const [newHabitModalData, setNewHabitModalData] = useState<{
     isOpen: boolean;
@@ -103,6 +104,7 @@ export default function Index() {
           completedDates: habit.completed_dates || [],
           totalDays: habit.total_days || 0,
           is_public: habit.is_public || true,
+          achieved_at: habit.achieved_at,
         }));
         setHabits(formattedData);
       }
@@ -181,7 +183,9 @@ export default function Index() {
           completed_dates: updatedCompletedDates,
           streak,
           total_days: updatedCompletedDates.length,
-          achieved_at: !isCompleted ? new Date().toISOString() : null,
+          achieved_at: !isCompleted
+            ? new Date().toISOString()
+            : habit.achieved_at,
         })
         .eq('id', habitId)
         .eq('user_id', session?.user?.id)

--- a/app/(tabs)/social.tsx
+++ b/app/(tabs)/social.tsx
@@ -8,15 +8,10 @@ import {
   AvatarFallbackText,
 } from '@/components/ui/avatar';
 import { HStack } from '@/components/ui/hstack';
-import {
-  BicepsFlexed,
-  Flame,
-  Medal,
-  GraduationCap,
-  Heart,
-} from 'lucide-react-native';
+import { BicepsFlexed, Flame, Medal, GraduationCap } from 'lucide-react-native';
 import { supabase } from '@/lib/supabase';
 import { RefreshControl, ScrollView, TouchableOpacity } from 'react-native';
+import { Icon } from '@/components/ui/icon';
 
 interface PublicHabit {
   id: string;
@@ -118,10 +113,11 @@ export default function Social() {
   };
 
   const fetchPublicHabits = async () => {
+    setRefreshing(true);
     try {
       // 今日の日付を取得（YYYY-MM-DD形式）
       const today = new Date().toISOString().split('T')[0];
-
+      
       const { data, error } = await supabase
         .from('habits')
         .select(
@@ -132,17 +128,19 @@ export default function Social() {
             username,
             avatar_url
           )
-        `,
+        `
         )
         .eq('is_public', true)
         .contains('completed_dates', [today])
         .order('updated_at', { ascending: false })
         .limit(50);
-
+      
       if (error) throw error;
       setPublicHabits(data || []);
     } catch (error) {
       console.error('Error fetching public habits:', error);
+    } finally {
+      setRefreshing(false);
     }
   };
 
@@ -221,12 +219,13 @@ export default function Social() {
                       onPress={() => toggleLike(habit.id)}
                       className="flex-row items-center"
                     >
-                      <Heart
+                      <Icon
+                        as={Flame}
                         color={likedHabits[habit.id] ? 'red' : 'gray'}
-                        size={20}
+                        size="lg"
                       />
-                      <Text className="ml-1 text-sm text-gray-500">
-                        {habit.likes ?? 0}
+                      <Text className="text-sm text-gray-500 min-w-[20px] text-center">
+                        {habit.likes}
                       </Text>
                     </TouchableOpacity>
                   </HStack>

--- a/app/(tabs)/social.tsx
+++ b/app/(tabs)/social.tsx
@@ -8,9 +8,15 @@ import {
   AvatarFallbackText,
 } from '@/components/ui/avatar';
 import { HStack } from '@/components/ui/hstack';
-import { BicepsFlexed, Flame, Medal, GraduationCap } from 'lucide-react-native';
+import {
+  BicepsFlexed,
+  Flame,
+  Medal,
+  GraduationCap,
+  Heart,
+} from 'lucide-react-native';
 import { supabase } from '@/lib/supabase';
-import { RefreshControl, ScrollView } from 'react-native';
+import { RefreshControl, ScrollView, TouchableOpacity } from 'react-native';
 
 interface PublicHabit {
   id: string;
@@ -18,6 +24,8 @@ interface PublicHabit {
   streak: number;
   completed_dates: string[];
   updated_at: string;
+  achieved_at?: string;
+  likes?: number;
   profiles: {
     id: string;
     username: string;
@@ -82,6 +90,32 @@ function StreakBadge({ streak }: StreakBadgeProps) {
 export default function Social() {
   const [publicHabits, setPublicHabits] = useState<PublicHabit[]>([]);
   const [refreshing, setRefreshing] = useState(false);
+  const [likedHabits, setLikedHabits] = useState<{ [id: string]: boolean }>({});
+
+  const toggleLike = async (habitId: string): Promise<void> => {
+    const habit = publicHabits.find((h) => h.id === habitId);
+    if (!habit) return;
+
+    const currentLikes = habit.likes ?? 0;
+    const newLiked = !likedHabits[habitId];
+    const newLikeCount = newLiked
+      ? currentLikes + 1
+      : Math.max(currentLikes - 1, 0);
+
+    const { error } = await supabase
+      .from('habits')
+      .update({ likes: newLikeCount })
+      .eq('id', habitId);
+    if (error) {
+      console.error('Error updating like count:', error);
+      return;
+    }
+
+    setLikedHabits((prev) => ({ ...prev, [habitId]: newLiked }));
+    setPublicHabits((prev) =>
+      prev.map((h) => (h.id === habitId ? { ...h, likes: newLikeCount } : h)),
+    );
+  };
 
   const fetchPublicHabits = async () => {
     try {
@@ -179,9 +213,23 @@ export default function Social() {
                   <Text className="text-sm text-gray-500">
                     累計{habit.completed_dates?.length || 0}日達成
                   </Text>
-                  <Text className="text-sm text-gray-400">
-                    {formatTime(habit.updated_at)}
-                  </Text>
+                  <HStack className="items-center justify-between">
+                    <Text className="text-sm text-gray-400">
+                      {formatTime(habit.achieved_at ?? habit.updated_at)}
+                    </Text>
+                    <TouchableOpacity
+                      onPress={() => toggleLike(habit.id)}
+                      className="flex-row items-center"
+                    >
+                      <Heart
+                        color={likedHabits[habit.id] ? 'red' : 'gray'}
+                        size={20}
+                      />
+                      <Text className="ml-1 text-sm text-gray-500">
+                        {habit.likes ?? 0}
+                      </Text>
+                    </TouchableOpacity>
+                  </HStack>
                 </VStack>
               </Box>
             ))}

--- a/app/(tabs)/social.tsx
+++ b/app/(tabs)/social.tsx
@@ -19,7 +19,7 @@ interface PublicHabit {
   streak: number;
   completed_dates: string[];
   updated_at: string;
-  achieved_at?: string;
+  achieved_at: string;
   likes?: number;
   profiles: {
     id: string;
@@ -117,7 +117,7 @@ export default function Social() {
     try {
       // 今日の日付を取得（YYYY-MM-DD形式）
       const today = new Date().toISOString().split('T')[0];
-      
+
       const { data, error } = await supabase
         .from('habits')
         .select(
@@ -128,13 +128,13 @@ export default function Social() {
             username,
             avatar_url
           )
-        `
+        `,
         )
         .eq('is_public', true)
         .contains('completed_dates', [today])
         .order('updated_at', { ascending: false })
         .limit(50);
-      
+
       if (error) throw error;
       setPublicHabits(data || []);
     } catch (error) {
@@ -213,7 +213,7 @@ export default function Social() {
                   </Text>
                   <HStack className="items-center justify-between">
                     <Text className="text-sm text-gray-400">
-                      {formatTime(habit.achieved_at ?? habit.updated_at)}
+                      {formatTime(habit.achieved_at)}
                     </Text>
                     <TouchableOpacity
                       onPress={() => toggleLike(habit.id)}

--- a/app/(tabs)/social.tsx
+++ b/app/(tabs)/social.tsx
@@ -157,6 +157,7 @@ export default function Social() {
       return `${minutes}分前`;
     }
     return date.toLocaleTimeString('ja-JP', {
+      timeZone: 'Asia/Tokyo',
       hour: '2-digit',
       minute: '2-digit',
     });

--- a/components/HabitFab.tsx
+++ b/components/HabitFab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { Fab, FabIcon, FabLabel } from '@/components/ui/fab';
 import { AddIcon } from '@/components/ui/icon';
 import { Input, InputField } from '@/components/ui/input';
@@ -26,11 +26,14 @@ export default function HabitFab({
   maxHabitsReached,
 }: HabitFabProps) {
   const [showModal, setShowModal] = useState(false);
-  const [newHabit, setNewHabit] = useState('');
   const [showError, setShowError] = useState(false);
   const [errorType, setErrorType] = useState<
     'empty' | 'tooLong' | 'duplicate' | null
   >(null);
+
+  const habitTextRef = useRef<string>('');
+
+  const [inputKey, setInputKey] = useState(Math.random().toString(36));
 
   const handleSubmit = async () => {
     if (maxHabitsReached) {
@@ -39,12 +42,13 @@ export default function HabitFab({
       return;
     }
 
-    const hasError = await onAddHabit(newHabit);
+    const habitText = habitTextRef.current;
+    const hasError = await onAddHabit(habitText);
     if (hasError) {
       setShowError(true);
-      if (!newHabit.trim()) {
+      if (!habitText.trim()) {
         setErrorType('empty');
-      } else if (newHabit.length > 16) {
+      } else if (habitText.length > 16) {
         setErrorType('tooLong');
       } else {
         setErrorType('duplicate');
@@ -52,7 +56,8 @@ export default function HabitFab({
     } else {
       setShowError(false);
       setErrorType(null);
-      setNewHabit('');
+      habitTextRef.current = '';
+      setInputKey(Math.random().toString(36));
       setShowModal(false);
     }
   };
@@ -71,7 +76,8 @@ export default function HabitFab({
         isOpen={showModal}
         onClose={() => {
           setShowModal(false);
-          setNewHabit('');
+          habitTextRef.current = '';
+          setInputKey(Math.random().toString(36));
           setShowError(false);
           setErrorType(null);
         }}
@@ -89,10 +95,14 @@ export default function HabitFab({
                   isReadOnly={false}
                 >
                   <InputField
+                    key={inputKey}
                     placeholder="新しい習慣を入力..."
-                    value={newHabit}
                     onChangeText={(text) => {
-                      setNewHabit(text);
+                      habitTextRef.current = text;
+                      setShowError(false);
+                      setErrorType(null);
+                    }}
+                    onFocus={() => {
                       setShowError(false);
                       setErrorType(null);
                     }}
@@ -118,7 +128,8 @@ export default function HabitFab({
               style={{ marginRight: 12 }}
               onPress={() => {
                 setShowModal(false);
-                setNewHabit('');
+                habitTextRef.current = '';
+                setInputKey(Math.random().toString(36));
               }}
             >
               <ButtonText>キャンセル</ButtonText>

--- a/supabase/migrations/202502012051_add_likes_clumn_to_habits_table.sql
+++ b/supabase/migrations/202502012051_add_likes_clumn_to_habits_table.sql
@@ -1,0 +1,3 @@
+-- This migration adds a "likes" column to the "habits" table.
+ALTER TABLE habits
+ADD COLUMN likes integer DEFAULT 0 NOT NULL;

--- a/supabase/migrations/202502012055_update_likes_rls_policy.sql
+++ b/supabase/migrations/202502012055_update_likes_rls_policy.sql
@@ -1,0 +1,12 @@
+-- This migration creates a new Row-Level Security (RLS) policy that allows an authenticated user
+-- to update the "likes" column for any habit that is public.
+-- Ensure that your habits table has RLS enabled:
+ALTER TABLE habits ENABLE ROW LEVEL SECURITY;
+
+-- Create a policy that allows update to the "likes" column if the habit is public.
+CREATE POLICY "Allow update likes on public habits"
+  ON habits
+  FOR UPDATE
+  TO authenticated
+  USING (is_public = true)
+  WITH CHECK (true); 

--- a/supabase/migrations/202502012128_add_archived_at_column_to_habits_table.sql
+++ b/supabase/migrations/202502012128_add_archived_at_column_to_habits_table.sql
@@ -1,0 +1,5 @@
+-- supabase/migrations/202502012100_add_achieved_at_column_to_habits_table.sql
+-- This migration adds the achieved_at column to the habits table.
+
+ALTER TABLE habits
+ADD COLUMN achieved_at timestamp with time zone;


### PR DESCRIPTION
<img width="484" alt="image" src="https://github.com/user-attachments/assets/b4f71da6-03bb-42f9-abbe-059fcfda0895" />
This pull request includes several changes to enhance the functionality of the habit tracking and social features, as well as updates to the database schema to support these new features. The most important changes include the addition of the `achieved_at` and `likes` fields, the implementation of a like feature for public habits, and the use of a ref for managing new habit input in the `HabitFab` component.

### Enhancements to Habit Tracking and Social Features:

* [`app/(tabs)/index.tsx`](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdL52-R62): Added a new `achieved_at` field to the `Habit` type and updated the logic to set this field when a habit is marked as completed. [[1]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdL52-R62) [[2]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR107) [[3]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR186-R188)

* [`app/(tabs)/social.tsx`](diffhunk://#diff-995ddc3551b48c248d1c61d05932190fbcb17bc33ed90d279c8cc0bd2820ab9bL13-R23): Added a new `likes` field to the `PublicHabit` interface, implemented a `toggleLike` function to handle liking/unliking habits, and updated the UI to display the like button and count. [[1]](diffhunk://#diff-995ddc3551b48c248d1c61d05932190fbcb17bc33ed90d279c8cc0bd2820ab9bL13-R23) [[2]](diffhunk://#diff-995ddc3551b48c248d1c61d05932190fbcb17bc33ed90d279c8cc0bd2820ab9bR88-R116) [[3]](diffhunk://#diff-995ddc3551b48c248d1c61d05932190fbcb17bc33ed90d279c8cc0bd2820ab9bR215-R232)

### Database Schema Updates:

* [`supabase/migrations/202502012051_add_likes_clumn_to_habits_table.sql`](diffhunk://#diff-0332d66f750bb510c129394d9fe49933718d0845679304a11391fb3a4495c87aR1-R3): Added a new `likes` column to the `habits` table with a default value of 0.

* [`supabase/migrations/202502012055_update_likes_rls_policy.sql`](diffhunk://#diff-1e30737a635b738966a289e84132a8d2771ce2e63ce0673707477b213e9c449dR1-R12): Created a new Row-Level Security (RLS) policy to allow authenticated users to update the `likes` column for public habits.

* [`supabase/migrations/202502012128_add_archived_at_column_to_habits_table.sql`](diffhunk://#diff-442d86f8e604b181ad7137875201852fa02fb575b4447f25b1f2c7140bb2b917R1-R5): Added a new `achieved_at` column to the `habits` table to store the timestamp of when a habit was achieved.

### Improvements to `HabitFab` Component:

* [`components/HabitFab.tsx`](diffhunk://#diff-dced53775d2f1beca6754ed88352f9c4ca9f8513ba1998aa4e6dac3e902721a2L1-R1): Replaced the local state for the new habit input with a ref to better manage the input field, especially when resetting the form after submission or cancellation. [[1]](diffhunk://#diff-dced53775d2f1beca6754ed88352f9c4ca9f8513ba1998aa4e6dac3e902721a2L1-R1) [[2]](diffhunk://#diff-dced53775d2f1beca6754ed88352f9c4ca9f8513ba1998aa4e6dac3e902721a2L29-R60) [[3]](diffhunk://#diff-dced53775d2f1beca6754ed88352f9c4ca9f8513ba1998aa4e6dac3e902721a2L74-R80) [[4]](diffhunk://#diff-dced53775d2f1beca6754ed88352f9c4ca9f8513ba1998aa4e6dac3e902721a2R98-R105) [[5]](diffhunk://#diff-dced53775d2f1beca6754ed88352f9c4ca9f8513ba1998aa4e6dac3e902721a2L121-R132)