### PR TITLE
feat: いいねに関するテーブル構造の見直し

### DIFF
--- a/supabase/migrations/202502032342_create_likes_table.up.sql
+++ b/supabase/migrations/202502032342_create_likes_table.up.sql
@@ -1,0 +1,11 @@
+-- pgcrypto 拡張機能の有効化（gen_random_uuid() を利用するため）
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS likes (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL,
+    habit_id uuid NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT likes_user_id_fk FOREIGN KEY (user_id) REFERENCES profiles(id) ON DELETE CASCADE,
+    CONSTRAINT likes_habit_id_fk FOREIGN KEY (habit_id) REFERENCES habits(id) ON DELETE CASCADE
+); 

--- a/supabase/migrations/202502032344_remove_likes_column_from_habits.up.sql
+++ b/supabase/migrations/202502032344_remove_likes_column_from_habits.up.sql
@@ -1,0 +1,2 @@
+-- habitsテーブルからlikesカラムを削除するマイグレーション
+ALTER TABLE habits DROP COLUMN IF EXISTS likes; 


### PR DESCRIPTION
<img width="556" alt="image" src="https://github.com/user-
This pull request includes significant changes to the `Social` component and database schema to handle likes using a separate `likes` table rather than a column in the `habits` table. The most important changes include updating the logic for liking habits, modifying the data fetching and processing, and adding new database migrations.

Improvements to the `Social` component:

* [`app/(tabs)/social.tsx`](diffhunk://#diff-995ddc3551b48c248d1c61d05932190fbcb17bc33ed90d279c8cc0bd2820ab9bL94-R132): Updated the logic to handle likes by inserting or deleting records in the `likes` table instead of updating a `likes` column in the `habits` table. This involves fetching the current user, inserting or deleting a like record, and updating the like count accordingly.
* [`app/(tabs)/social.tsx`](diffhunk://#diff-995ddc3551b48c248d1c61d05932190fbcb17bc33ed90d279c8cc0bd2820ab9bL130-R173): Modified the data fetching query to include likes and process the data to count the number of likes for each habit. Adjusted the order of fetched habits to be in descending order of `achieved_at`.

Database schema changes:

* [`supabase/migrations/202502032342_create_likes_table.up.sql`](diffhunk://#diff-2236219531ba12ebacaa40821a53a6cf94e336effb9a0732214b37ff10415890R1-R11): Added a migration to create a new `likes` table with foreign keys referencing the `profiles` and `habits` tables.
* [`supabase/migrations/202502032344_remove_likes_column_from_habits.up.sql`](diffhunk://#diff-0c8b5ac9c1eceadad0ca0c7f29016312d89d3b9eea77ba03ce6a1a6de0c46a02R1-R2): Added a migration to remove the `likes` column from the `habits` table.