### PR TITLE
style: 目標の日付をカレンダーUIで判別可能に

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -58,6 +58,7 @@ export default function Index() {
     totalDays: number;
     is_public: boolean;
     achieved_at?: string;
+    goal?: number;
   };
 
   const [habits, setHabits] = useState<Habit[]>([]);
@@ -99,6 +100,7 @@ export default function Index() {
           totalDays: habit.total_days || 0,
           is_public: habit.is_public || true,
           achieved_at: habit.achieved_at,
+          goal: habit.goal,
         }));
         setHabits(formattedData);
       }
@@ -351,6 +353,7 @@ export default function Index() {
                   setNewHabitModalData((prev) => ({ ...prev, isOpen: false }))
                 }
                 habitName={newHabitModalData.habitName}
+                onGoalSet={fetchHabits}
               />
 
               {/* 週間ビュー */}

--- a/components/MonthView.tsx
+++ b/components/MonthView.tsx
@@ -6,6 +6,7 @@ interface Habit {
   id: string;
   name: string;
   completedDates: string[];
+  goal?: number;
 }
 
 interface MonthViewProps {
@@ -67,6 +68,24 @@ export function MonthView({ habits, currentDate }: MonthViewProps) {
   };
   const today = formatDate(new Date());
 
+  // 目標日を計算する関数を追加
+  const calculateGoalDates = () => {
+    const goalDates: string[] = [];
+    const today = new Date();
+
+    habits.forEach((habit) => {
+      if (habit.goal) {
+        const goalDate = new Date(today);
+        goalDate.setDate(goalDate.getDate() + habit.goal);
+        goalDates.push(formatDate(goalDate));
+      }
+    });
+
+    return goalDates;
+  };
+
+  const goalDates = calculateGoalDates();
+
   return (
     <Box className="bg-gray-800 rounded-xl p-4">
       {/* Weekday header (Monday-first) */}
@@ -89,6 +108,8 @@ export function MonthView({ habits, currentDate }: MonthViewProps) {
             const isCompleted = allCompletedDates.includes(dateStr);
             const isToday = dateStr === today;
             const isCurrentMonth = day.getMonth() === month;
+            const isGoalDate = goalDates.includes(dateStr);
+
             return (
               <Box key={di} className="flex-1 flex items-center justify-center">
                 <Box
@@ -96,6 +117,7 @@ export function MonthView({ habits, currentDate }: MonthViewProps) {
                     w-10 h-10 flex items-center justify-center rounded-lg
                     ${isCompleted ? 'bg-teal-500' : 'bg-transparent'}
                     ${isToday ? 'border-2 border-teal-300' : ''}
+                    ${isGoalDate ? 'border-2 border-orange-400' : ''}
                     ${!isCurrentMonth ? 'opacity-50' : ''}
                   `}
                 >

--- a/components/NewHabitModal.tsx
+++ b/components/NewHabitModal.tsx
@@ -21,12 +21,14 @@ interface NewHabitModalProps {
   isOpen: boolean;
   onClose: () => void;
   habitName: string;
+  onGoalSet?: () => void;
 }
 
 export default function NewHabitModal({
   isOpen,
   onClose,
   habitName,
+  onGoalSet,
 }: NewHabitModalProps) {
   const confettiRef = useRef<LottieView | null>(null);
   const [goal, setGoal] = useState(false);
@@ -51,6 +53,9 @@ export default function NewHabitModal({
             .eq('name', habitName);
           if (error) {
             console.error('Error updating habit goal', error);
+          } else {
+            // 目標設定が成功したら onGoalSet を呼び出す
+            onGoalSet?.();
           }
         } catch (err) {
           console.error('Error updating habit goal', err);


### PR DESCRIPTION
`MonthView`にある日付のうち、`NewHabitModal`で設定した目標の日付の枠線をオレンジ色にして、目標の日付を識別できるようにした
![B2E11819-85EE-4BC2-B168-8C8A4DC1C1D4](https://github.com/user-attachments/assets/d5d73cd8-7785-45b1-978c-6b50a6bd4fc1)
